### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction to Taskless
 
-Welcome to Taskless! Taskless is designed to take the infrastructure pain out of setting up and maintaing a Job Queueing system, and excels in a serverless or edge-function environment. It can be used anywhere you've got publicly reachable URLs and wish to call them on a schedule or in response to a user action.
+Welcome to Taskless! Taskless is designed to take the infrastructure pain out of setting up and maintaining a Job Queueing system, and excels in a serverless or edge-function environment. It can be used anywhere you've got publicly reachable URLs and wish to call them on a schedule or in response to a user action.
 
 Questions? We're happy to help. Join the [Taskless Community](https://github.com/taskless/taskless/discussions/categories/q-a) on Github.
 

--- a/docs/concepts/encryption.md
+++ b/docs/concepts/encryption.md
@@ -24,7 +24,7 @@ Internally, a Taskless job looks like this (actual sample taken from Taskless' o
 In the clear, we pass `v` which tells us the version of the Taskless body, as well as the `transport` key. `transport` tells us about the envelope we used to encrypt the contents of `text`.
 
 - `ev` tells us the envelope version in case we need to make backwards incompatible changes
-- `alg` tells us the encryption algorythm used. By default, Taskless uses [AES-256](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard), the same standard used by Google, NIST, and others to secure sensitive data
+- `alg` tells us the encryption algorithm used. By default, Taskless uses [AES-256](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard), the same standard used by Google, NIST, and others to secure sensitive data
 - `atl` tells us the AuthTag length and simplifies validating the length of the `at` property
 - `at` is the AuthTag itself, which helps us confirm the message was not altered
 - `iv` is the [Initialization Vector](https://en.wikipedia.org/wiki/Initialization_vector) which makes it computationally impossible to reverse our encrypted text back into a key

--- a/docs/get-started/nextjs.md
+++ b/docs/get-started/nextjs.md
@@ -93,7 +93,7 @@ const job = await EchoQueue.enqueue("job-name", {
 });
 ```
 
-Enqueing a new Job takes two required arguments, plus one optional:
+Enqueuing a new Job takes two required arguments, plus one optional:
 
 1. The `job name`, which uniquely identifies the job. It's a good idea to provide a recognizable name for debugging purposes. When a Job is enqueued with an identical name, it will be update the existing job while preserving its run history.
 2. The `payload` you want to pass to your Job's handler callback (from `createQueue` above)

--- a/docs/get-started/other.md
+++ b/docs/get-started/other.md
@@ -20,13 +20,13 @@ const queue = new Queue<T>({
 ```
 
 - `route`: The URL path name this Queue will be reachable on
-- `handler`: A Promise-returning callback that recieves a Job of type `T` and associated metadata
+- `handler`: A Promise-returning callback that receives a Job of type `T` and associated metadata
 - `queueOptions`: The [`QueueOptions`](/docs/packages/client/queue.md#queue-options) for this queue
 - `jobOptions`: The default [`JobOptions`](/docs/packages/client/queue.md#job-options) for this queue
 
 ## Exposing Taskless Queue Methods
 
-The Taskless Queue includes `enqueue` and `remove`. You may optionally implement wrappers around any of these depending on your needs. Most intgerations attach identically named methods to their API Handler, passing the values directly through to the Taskless Queue.
+The Taskless Queue includes `enqueue` and `remove`. You may optionally implement wrappers around any of these depending on your needs. Most integrations attach identically named methods to their API Handler, passing the values directly through to the Taskless Queue.
 
 ## Receiving Requests
 
@@ -52,7 +52,7 @@ By default, returning from your job handler will be seen as a successful call, r
 
 ## Examples
 
-- [@taskless/next](https://github.com/taskless/taskless/blob/main/packages/next/src/index.ts) is a full example of creating a custom intgeration that adhears to the Next.JS API signature while also providing the standard set of Taskless methods. Additionally, it exposes `withQueue`, a pattern that's used for Next.js middleware when wrapping handlers with new behavior.
+- [@taskless/next](https://github.com/taskless/taskless/blob/main/packages/next/src/index.ts) is a full example of creating a custom integration that adheres to the Next.JS API signature while also providing the standard set of Taskless methods. Additionally, it exposes `withQueue`, a pattern that's used for Next.js middleware when wrapping handlers with new behavior.
 
 ## Related
 

--- a/docs/packages/client.md
+++ b/docs/packages/client.md
@@ -35,7 +35,7 @@ Taskless Queues are stateless classes that only need to persist for the lifecycl
 
 ## Constructing a Queue
 
-While the `createQueue` interface is a more natural API, the `TasklessQueueConfig` provides all of the same arguments in an object literal. This allows us to add new features and options to the Queue, without forcing possibly breaking changes on the intergations.
+While the `createQueue` interface is a more natural API, the `TasklessQueueConfig` provides all of the same arguments in an object literal. This allows us to add new features and options to the Queue, without forcing possibly breaking changes on the integrations.
 
 - `name: string` Describes the name of the queue
 - `route: string | (() => string)` Describes the route this queue is reachable on. If `typeof route === "function"`, then the route will be evaluated as lazily as possible. This allows for integrations such as [express](./express.md) to handle a late-binding of the route parameter in situations where the Taskless queue is not yet mounted to the routing structure

--- a/docs/packages/client/env.md
+++ b/docs/packages/client/env.md
@@ -1,6 +1,6 @@
 # Taskless Environment Variables
 
-Most options in Taskless can be represented via [Environment Variables](https://en.wikipedia.org/wiki/Environment_variable) or colloquially "env" values. Env values are not committed to your repository and often contain senstive information such as secrets. Most deployment targets including Vercel, Heroku, and Netlify all allow you to specify env values as part of your app's configuration.
+Most options in Taskless can be represented via [Environment Variables](https://en.wikipedia.org/wiki/Environment_variable) or colloquially "env" values. Env values are not committed to your repository and often contain sensitive information such as secrets. Most deployment targets including Vercel, Heroku, and Netlify all allow you to specify env values as part of your app's configuration.
 
 Taskless recommends storing the bulk of your configuration in env values.
 

--- a/docs/packages/express.md
+++ b/docs/packages/express.md
@@ -40,7 +40,7 @@ Create an [Express Router](https://expressjs.com/en/4x/api.html#router), optiona
 
 ## Exported from @taskless/client
 
-In addition to the above, the following items are rexported from `@taskless/client` as a convienence.
+In addition to the above, the following items are reexported from `@taskless/client` as a convenience.
 
 - [JobError](./client/job-error.md) An error object capable of handling advanced [return codes](./client/return-codes.md)
 - [Queue](./client/queue.md) The Taskless Queue object for advanced integrations

--- a/docs/packages/next.md
+++ b/docs/packages/next.md
@@ -37,11 +37,11 @@ Cancel a job, removing it from the active queue by the specified `name`. Returns
 ### Next Methods
 
 `withQueue(wrappedHandler: NextApiHandler): TasklessNextApiHandler`
-When using integrations such as [sentry for next.js](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure), your next.js handler is wraped in a manner that obscures the Taskless methods. When this happens, calls to the core methods such as `enqueue` will result in an error trying to call an undefined value. To work around this limitation, the Next.js intergation exposes `withQueue` method, which will reattach the core methods to the provided `NextApiHandler`.
+When using integrations such as [sentry for next.js](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure), your next.js handler is wrapped in a manner that obscures the Taskless methods. When this happens, calls to the core methods such as `enqueue` will result in an error trying to call an undefined value. To work around this limitation, the Next.js integration exposes `withQueue` method, which will reattach the core methods to the provided `NextApiHandler`.
 
 ## Exported from @taskless/client
 
-In addition to the above, the following items are rexported from `@taskless/client` as a convienence.
+In addition to the above, the following items are reexported from `@taskless/client` as a convenience.
 
 - [JobError](./client/job-error.md) An error object capable of handling advanced [return codes](./client/return-codes.md)
 - [Queue](./client/queue.md) The Taskless Queue object for advanced integrations


### PR DESCRIPTION
Fix typos in the docs.

Close #2 